### PR TITLE
chore: do not make serde_json optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "handlebars_misc_helpers"
 version = "0.12.2-dev"
 authors = ["David Bernard"]
-edition = "2018"
+edition = "2021"
 description = "A collection of helpers for handlebars (rust) to manage string, json, yaml, toml, path, file, http request."
 readme = "README.md"
 license = "CC0-1.0"
@@ -29,7 +29,7 @@ Inflector = { version = "^0.11", optional = true }
 lazy_static = { version = "^1.4", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["blocking"] }
 serde = { version = "^1", features = ["rc"], optional = true }
-serde_json = { version = "^1", optional = true }
+serde_json = "^1"
 serde_yaml = { version = "^0.8", optional = true }
 thiserror = "1.0"
 toml = { version = "^0.5", optional = true, features = ["preserve_order"] }
@@ -48,5 +48,5 @@ string = ["Inflector", "enquote"]
 http_attohttpc = ["attohttpc", "http_fct"]
 http_reqwest = ["reqwest", "http_fct"]
 http_fct = []
-json = ["lazy_static", "serde", "serde_json", "serde_yaml", "toml"]
+json = ["lazy_static", "serde", "serde_yaml", "toml"]
 jsonnet = ["jsonnet-rs"]


### PR DESCRIPTION
If you want to not use default-features and do not use json it was not working. I also upgraded the rust edition