### PR TITLE
Correct `from_json` example to use correct destination format

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ hello = "1.2.3"
 }</code></pre></td>
 </tr>
 <tr>
-<td><pre><code>{{#from_json format="toml"}}
+<td><pre><code>{{#from_json format="yaml"}}
 {"foo":{"bar":{"baz":true}}}
 {{/from_json}}</code></pre>
 </td>


### PR DESCRIPTION
The `from_json` -> `yaml` example is corrected from `toml` to `yaml`.